### PR TITLE
Grid now clears when a player skips or forfeits

### DIFF
--- a/app.js
+++ b/app.js
@@ -377,13 +377,16 @@ function skipTurn() {
 
   // if the skip count is equal to the number of players, end the game
   if (skipCount === 2) {
-    document.getElementById("error").textContent =
-      "You skipped your turn too many times! You have lost the game!";
     skipArray.push("loss");
     skipWinsAndLosses(skipArray);
     stopTimer();
     skipCount = 0;
+    clearEverything();
+    document.getElementById("error").textContent =
+      "You skipped your turn too many times! You have lost the game!";
   } else {
+    //Clear grid for next player
+    clearGrid();
     // Clear error message
     document.getElementById("error").textContent =
       "You have skipped your turn. Next player, please!";


### PR DESCRIPTION
I have fixed the bug so that the grid will clear any occupied squares when a player skips their turn. Additionally, if a player skips multiple turns, the grid will now remove both occupied and blocked squares and end the game. 